### PR TITLE
Support suites that have the same option but different extraOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "nyc": {
-    "include": ["src/**"]
+    "include": [
+      "src/**"
+    ]
   },
   "dependencies": {
+    "lodash": "^4.17.10",
     "metrics-graphics": "^2.13.0",
     "prop-types": "^15.6.1",
     "query-string": "^6.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,16 @@
 import { Component } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Route } from 'react-router-dom';
 import './App.css';
-import ListSuites from './components/list_suites';
+import ListSuites from './components/listSuites';
+import PlotSuite from './components/plotSuite';
 
-const DEFAULT_BENCHMARKS = [
-  'ARES6',
-  'JetStream',
-  'motionmark_htmlsuite',
-  'motionmark_animometer',
-];
+const DEFAULT_BENCHMARKS = ['ARES6', 'JetStream', 'motionmark_htmlsuite', 'motionmark_animometer'];
 
 export default class App extends Component {
   state = {
     hasError: undefined,
     configuration: {
-      linux64: DEFAULT_BENCHMARKS,
+      linux64: DEFAULT_BENCHMARKS + ['dromaeo_dom'],
       'windows7-32': DEFAULT_BENCHMARKS,
       'windows10-64': DEFAULT_BENCHMARKS,
     },
@@ -32,12 +28,12 @@ export default class App extends Component {
       return <h1>Something went wrong.</h1>;
     }
 
-    const { configuration } = this.state;
-
     return (
       <div>
         <Link to="/" href="/">Home</Link>
-        <ListSuites configuration={configuration} />
+        <ListSuites configuration={this.state.configuration} />
+        <hr />
+        <Route path="/:platform/:suite" render={PlotSuite} />
       </div>
     );
   }

--- a/src/components/listSuites.jsx
+++ b/src/components/listSuites.jsx
@@ -1,19 +1,5 @@
-import { Route, Link } from 'react-router-dom';
 import propTypes from 'prop-types';
-import PerfherderContainer from '../containers/perfherder';
-
-const PlotSuite = ({ match }) => (
-  <div>
-    <PerfherderContainer
-      suite={match.params.suite}
-      platform={match.params.platform}
-    />
-  </div>
-);
-
-PlotSuite.propTypes = {
-  match: propTypes.shape({}).isRequired,
-};
+import { Link } from 'react-router-dom';
 
 const ListSuites = ({ configuration }) => (
   <div>
@@ -33,8 +19,6 @@ const ListSuites = ({ configuration }) => (
         ))}
       </div>
     ))}
-    <hr />
-    <Route path="/:platform/:suite" render={PlotSuite} />
   </div>
 );
 

--- a/src/components/plotSuite.jsx
+++ b/src/components/plotSuite.jsx
@@ -1,0 +1,18 @@
+import propTypes from 'prop-types';
+import PerfherderContainer from '../containers/perfherder';
+import configuration from '../configuration';
+
+const PlotSuite = ({ match }) => (
+  <div>
+    <PerfherderContainer
+      {...match.params}
+      {...configuration[match.params.suite]}
+    />
+  </div>
+);
+
+PlotSuite.propTypes = {
+  match: propTypes.shape({}).isRequired,
+};
+
+export default PlotSuite;

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,0 +1,9 @@
+const SUITE_CONFIGURATION = {
+  ARES6: { buildType: 'pgo', extraOptions: ['e10s', 'stylo'] },
+  JetStream: { buildType: 'pgo', extraOptions: ['e10s', 'stylo'] },
+  dromaeo_dom: { buildType: 'pgo', extraOptions: ['e10s', 'stylo'] },
+  motionmark_htmlsuite: { buildType: 'pgo', extraOptions: ['e10s', 'stylo'] },
+  motionmark_animometer: { buildType: 'pgo', extraOptions: ['e10s', 'stylo'] },
+};
+
+export default SUITE_CONFIGURATION;

--- a/src/containers/perfherder.jsx
+++ b/src/containers/perfherder.jsx
@@ -9,25 +9,25 @@ export default class PerfherderContainer extends Component {
   }
 
   async componentDidMount() {
-    const { perfherderUrl, data } = await subbenchmarksData(
-      this.props.platform,
-      this.props.suite,
-    );
-    // eslint-disable-next-line
-    this.setState({ perfherderUrl, data });
+    this.fetchPerfherderData();
   }
 
   async componentDidUpdate(prevProps) {
     // The component has been called with new props and we
     // need to update the state or the old state will be used
     if (this.props.suite !== prevProps.suite) {
-      const { perfherderUrl, data } = await subbenchmarksData(
-        this.props.platform,
-        this.props.suite,
-      );
-      // eslint-disable-next-line
-      this.setState({ perfherderUrl, data });
+      this.fetchPerfherderData();
     }
+  }
+
+  async fetchPerfherderData() {
+    const { perfherderUrl, data } = await subbenchmarksData(
+      this.props.platform,
+      this.props.suite,
+      this.props.buildType,
+      this.props.extraOptions,
+    );
+    this.setState({ perfherderUrl, data });
   }
 
   render() {
@@ -70,6 +70,8 @@ export default class PerfherderContainer extends Component {
 }
 
 PerfherderContainer.propTypes = {
+  buildType: propTypes.string.isRequired,
+  extraOptions: propTypes.arrayOf(propTypes.string).isRequired,
   platform: propTypes.string.isRequired,
   suite: propTypes.string.isRequired,
 };

--- a/test/expected/linux64DromaeoDomExpectedData.json
+++ b/test/expected/linux64DromaeoDomExpectedData.json
@@ -1,0 +1,549 @@
+{
+  "perfherderUrl": "https://treeherder.mozilla.org/perf.html#/graphs?timerange=7776000&series=mozilla-central,1651446,1,1&series=mozilla-central,1651447,1,1&series=mozilla-central,1651448,1,1&series=mozilla-central,1651449,1,1",
+  "data": {
+    "793d36ca61ba5e3727542b170237e7192c50cc6b": {
+      "meta": {
+        "url": "https://treeherder.mozilla.org/perf.html#/graphs?timerange=7776000&series=mozilla-central,793d36ca61ba5e3727542b170237e7192c50cc6b,1,1",
+        "extra_options": [
+          "e10s",
+          "stylo"
+        ],
+        "parent_signature": "947870e091eef0257755ce0e6fd6302e1704c15b",
+        "machine_platform": "linux64",
+        "id": 1651447,
+        "option_collection_hash": "f69e1b00908837bf0550250abb1645014317e8ec",
+        "framework_id": 1,
+        "test": "modify.html",
+        "suite": "dromaeo_dom",
+        "lower_is_better": false
+      },
+      "data": [
+        {
+          "push_id": 350159,
+          "value": 709.93,
+          "signature_id": 1651447,
+          "id": 494103356,
+          "push_timestamp": 1529944466,
+          "job_id": 184734903,
+          "datetime": "2018-06-25T16:34:26.000Z"
+        },
+        {
+          "push_id": 350222,
+          "value": 732.16,
+          "signature_id": 1651447,
+          "id": 494234158,
+          "push_timestamp": 1529953295,
+          "job_id": 184785927,
+          "datetime": "2018-06-25T19:01:35.000Z"
+        },
+        {
+          "push_id": 350224,
+          "value": 739.69,
+          "signature_id": 1651447,
+          "id": 494227591,
+          "push_timestamp": 1529953361,
+          "job_id": 184783441,
+          "datetime": "2018-06-25T19:02:41.000Z"
+        },
+        {
+          "push_id": 350459,
+          "value": 746.11,
+          "signature_id": 1651447,
+          "id": 494637210,
+          "push_timestamp": 1530004839,
+          "job_id": 184888669,
+          "datetime": "2018-06-26T09:20:39.000Z"
+        },
+        {
+          "push_id": 350564,
+          "value": 741.25,
+          "signature_id": 1651447,
+          "id": 494931132,
+          "push_timestamp": 1530024738,
+          "job_id": 184962506,
+          "datetime": "2018-06-26T14:52:18.000Z"
+        },
+        {
+          "push_id": 350565,
+          "value": 704.93,
+          "signature_id": 1651447,
+          "id": 494940433,
+          "push_timestamp": 1530024819,
+          "job_id": 184965119,
+          "datetime": "2018-06-26T14:53:39.000Z"
+        },
+        {
+          "push_id": 350749,
+          "value": 737.31,
+          "signature_id": 1651447,
+          "id": 495284456,
+          "push_timestamp": 1530050017,
+          "job_id": 185041512,
+          "datetime": "2018-06-26T21:53:37.000Z"
+        },
+        {
+          "push_id": 350981,
+          "value": 732.79,
+          "signature_id": 1651447,
+          "id": 495722199,
+          "push_timestamp": 1530095079,
+          "job_id": 185135941,
+          "datetime": "2018-06-27T10:24:39.000Z"
+        },
+        {
+          "push_id": 350997,
+          "value": 733.45,
+          "signature_id": 1651447,
+          "id": 495745921,
+          "push_timestamp": 1530097540,
+          "job_id": 185143305,
+          "datetime": "2018-06-27T11:05:40.000Z"
+        },
+        {
+          "push_id": 351308,
+          "value": 723.12,
+          "signature_id": 1651447,
+          "id": 496242516,
+          "push_timestamp": 1530137129,
+          "job_id": 185267258,
+          "datetime": "2018-06-27T22:05:29.000Z"
+        },
+        {
+          "push_id": 351309,
+          "value": 744.14,
+          "signature_id": 1651447,
+          "id": 496255802,
+          "push_timestamp": 1530137288,
+          "job_id": 185270168,
+          "datetime": "2018-06-27T22:08:08.000Z"
+        },
+        {
+          "push_id": 351474,
+          "value": 704.69,
+          "signature_id": 1651447,
+          "id": 496496966,
+          "push_timestamp": 1530179042,
+          "job_id": 185340374,
+          "datetime": "2018-06-28T09:44:02.000Z"
+        },
+        {
+          "push_id": 351482,
+          "value": 717.6,
+          "signature_id": 1651447,
+          "id": 496517850,
+          "push_timestamp": 1530180318,
+          "job_id": 185345944,
+          "datetime": "2018-06-28T10:05:18.000Z"
+        }
+      ]
+    },
+    "78b8bec0338005afcc0c57d9622c18f55b0d6193": {
+      "meta": {
+        "url": "https://treeherder.mozilla.org/perf.html#/graphs?timerange=7776000&series=mozilla-central,78b8bec0338005afcc0c57d9622c18f55b0d6193,1,1",
+        "extra_options": [
+          "e10s",
+          "stylo"
+        ],
+        "parent_signature": "947870e091eef0257755ce0e6fd6302e1704c15b",
+        "machine_platform": "linux64",
+        "id": 1651446,
+        "option_collection_hash": "f69e1b00908837bf0550250abb1645014317e8ec",
+        "framework_id": 1,
+        "test": "attr.html",
+        "suite": "dromaeo_dom",
+        "lower_is_better": false
+      },
+      "data": [
+        {
+          "push_id": 350159,
+          "value": 5511.63,
+          "signature_id": 1651446,
+          "id": 494103354,
+          "push_timestamp": 1529944466,
+          "job_id": 184734903,
+          "datetime": "2018-06-25T16:34:26.000Z"
+        },
+        {
+          "push_id": 350222,
+          "value": 5621.31,
+          "signature_id": 1651446,
+          "id": 494234157,
+          "push_timestamp": 1529953295,
+          "job_id": 184785927,
+          "datetime": "2018-06-25T19:01:35.000Z"
+        },
+        {
+          "push_id": 350224,
+          "value": 5905.06,
+          "signature_id": 1651446,
+          "id": 494227589,
+          "push_timestamp": 1529953361,
+          "job_id": 184783441,
+          "datetime": "2018-06-25T19:02:41.000Z"
+        },
+        {
+          "push_id": 350459,
+          "value": 5673.6,
+          "signature_id": 1651446,
+          "id": 494637209,
+          "push_timestamp": 1530004839,
+          "job_id": 184888669,
+          "datetime": "2018-06-26T09:20:39.000Z"
+        },
+        {
+          "push_id": 350564,
+          "value": 5771.27,
+          "signature_id": 1651446,
+          "id": 494931131,
+          "push_timestamp": 1530024738,
+          "job_id": 184962506,
+          "datetime": "2018-06-26T14:52:18.000Z"
+        },
+        {
+          "push_id": 350565,
+          "value": 5479.64,
+          "signature_id": 1651446,
+          "id": 494940431,
+          "push_timestamp": 1530024819,
+          "job_id": 184965119,
+          "datetime": "2018-06-26T14:53:39.000Z"
+        },
+        {
+          "push_id": 350749,
+          "value": 5399.81,
+          "signature_id": 1651446,
+          "id": 495284455,
+          "push_timestamp": 1530050017,
+          "job_id": 185041512,
+          "datetime": "2018-06-26T21:53:37.000Z"
+        },
+        {
+          "push_id": 350981,
+          "value": 5648.08,
+          "signature_id": 1651446,
+          "id": 495722197,
+          "push_timestamp": 1530095079,
+          "job_id": 185135941,
+          "datetime": "2018-06-27T10:24:39.000Z"
+        },
+        {
+          "push_id": 350997,
+          "value": 5783.3,
+          "signature_id": 1651446,
+          "id": 495745919,
+          "push_timestamp": 1530097540,
+          "job_id": 185143305,
+          "datetime": "2018-06-27T11:05:40.000Z"
+        },
+        {
+          "push_id": 351308,
+          "value": 5659.75,
+          "signature_id": 1651446,
+          "id": 496242514,
+          "push_timestamp": 1530137129,
+          "job_id": 185267258,
+          "datetime": "2018-06-27T22:05:29.000Z"
+        },
+        {
+          "push_id": 351309,
+          "value": 5604.71,
+          "signature_id": 1651446,
+          "id": 496255801,
+          "push_timestamp": 1530137288,
+          "job_id": 185270168,
+          "datetime": "2018-06-27T22:08:08.000Z"
+        },
+        {
+          "push_id": 351474,
+          "value": 5802.03,
+          "signature_id": 1651446,
+          "id": 496496964,
+          "push_timestamp": 1530179042,
+          "job_id": 185340374,
+          "datetime": "2018-06-28T09:44:02.000Z"
+        },
+        {
+          "push_id": 351482,
+          "value": 5188.06,
+          "signature_id": 1651446,
+          "id": 496517845,
+          "push_timestamp": 1530180318,
+          "job_id": 185345944,
+          "datetime": "2018-06-28T10:05:18.000Z"
+        }
+      ]
+    },
+    "019d05b26679ad400a8ec0a8f4259b876e0a7845": {
+      "meta": {
+        "url": "https://treeherder.mozilla.org/perf.html#/graphs?timerange=7776000&series=mozilla-central,019d05b26679ad400a8ec0a8f4259b876e0a7845,1,1",
+        "extra_options": [
+          "e10s",
+          "stylo"
+        ],
+        "parent_signature": "947870e091eef0257755ce0e6fd6302e1704c15b",
+        "machine_platform": "linux64",
+        "id": 1651448,
+        "option_collection_hash": "f69e1b00908837bf0550250abb1645014317e8ec",
+        "framework_id": 1,
+        "test": "query.html",
+        "suite": "dromaeo_dom",
+        "lower_is_better": false
+      },
+      "data": [
+        {
+          "push_id": 350159,
+          "value": 43613.49,
+          "signature_id": 1651448,
+          "id": 494103359,
+          "push_timestamp": 1529944466,
+          "job_id": 184734903,
+          "datetime": "2018-06-25T16:34:26.000Z"
+        },
+        {
+          "push_id": 350222,
+          "value": 43800.94,
+          "signature_id": 1651448,
+          "id": 494234159,
+          "push_timestamp": 1529953295,
+          "job_id": 184785927,
+          "datetime": "2018-06-25T19:01:35.000Z"
+        },
+        {
+          "push_id": 350224,
+          "value": 43361.01,
+          "signature_id": 1651448,
+          "id": 494227593,
+          "push_timestamp": 1529953361,
+          "job_id": 184783441,
+          "datetime": "2018-06-25T19:02:41.000Z"
+        },
+        {
+          "push_id": 350459,
+          "value": 44384.92,
+          "signature_id": 1651448,
+          "id": 494637211,
+          "push_timestamp": 1530004839,
+          "job_id": 184888669,
+          "datetime": "2018-06-26T09:20:39.000Z"
+        },
+        {
+          "push_id": 350564,
+          "value": 43559.86,
+          "signature_id": 1651448,
+          "id": 494931133,
+          "push_timestamp": 1530024738,
+          "job_id": 184962506,
+          "datetime": "2018-06-26T14:52:18.000Z"
+        },
+        {
+          "push_id": 350565,
+          "value": 42958.32,
+          "signature_id": 1651448,
+          "id": 494940435,
+          "push_timestamp": 1530024819,
+          "job_id": 184965119,
+          "datetime": "2018-06-26T14:53:39.000Z"
+        },
+        {
+          "push_id": 350749,
+          "value": 44050.19,
+          "signature_id": 1651448,
+          "id": 495284457,
+          "push_timestamp": 1530050017,
+          "job_id": 185041512,
+          "datetime": "2018-06-26T21:53:37.000Z"
+        },
+        {
+          "push_id": 350981,
+          "value": 43613.63,
+          "signature_id": 1651448,
+          "id": 495722202,
+          "push_timestamp": 1530095079,
+          "job_id": 185135941,
+          "datetime": "2018-06-27T10:24:39.000Z"
+        },
+        {
+          "push_id": 350997,
+          "value": 44179.09,
+          "signature_id": 1651448,
+          "id": 495745923,
+          "push_timestamp": 1530097540,
+          "job_id": 185143305,
+          "datetime": "2018-06-27T11:05:40.000Z"
+        },
+        {
+          "push_id": 351308,
+          "value": 43183.1,
+          "signature_id": 1651448,
+          "id": 496242518,
+          "push_timestamp": 1530137129,
+          "job_id": 185267258,
+          "datetime": "2018-06-27T22:05:29.000Z"
+        },
+        {
+          "push_id": 351309,
+          "value": 43164.28,
+          "signature_id": 1651448,
+          "id": 496255803,
+          "push_timestamp": 1530137288,
+          "job_id": 185270168,
+          "datetime": "2018-06-27T22:08:08.000Z"
+        },
+        {
+          "push_id": 351474,
+          "value": 43267.26,
+          "signature_id": 1651448,
+          "id": 496496967,
+          "push_timestamp": 1530179042,
+          "job_id": 185340374,
+          "datetime": "2018-06-28T09:44:02.000Z"
+        },
+        {
+          "push_id": 351482,
+          "value": 43280.85,
+          "signature_id": 1651448,
+          "id": 496517856,
+          "push_timestamp": 1530180318,
+          "job_id": 185345944,
+          "datetime": "2018-06-28T10:05:18.000Z"
+        }
+      ]
+    },
+    "7174750fde7272ab7cb47cf0021604d46160dbc0": {
+      "meta": {
+        "url": "https://treeherder.mozilla.org/perf.html#/graphs?timerange=7776000&series=mozilla-central,7174750fde7272ab7cb47cf0021604d46160dbc0,1,1",
+        "extra_options": [
+          "e10s",
+          "stylo"
+        ],
+        "parent_signature": "947870e091eef0257755ce0e6fd6302e1704c15b",
+        "machine_platform": "linux64",
+        "id": 1651449,
+        "option_collection_hash": "f69e1b00908837bf0550250abb1645014317e8ec",
+        "framework_id": 1,
+        "test": "traverse.html",
+        "suite": "dromaeo_dom",
+        "lower_is_better": false
+      },
+      "data": [
+        {
+          "push_id": 350159,
+          "value": 573.21,
+          "signature_id": 1651449,
+          "id": 494103361,
+          "push_timestamp": 1529944466,
+          "job_id": 184734903,
+          "datetime": "2018-06-25T16:34:26.000Z"
+        },
+        {
+          "push_id": 350222,
+          "value": 574.66,
+          "signature_id": 1651449,
+          "id": 494234160,
+          "push_timestamp": 1529953295,
+          "job_id": 184785927,
+          "datetime": "2018-06-25T19:01:35.000Z"
+        },
+        {
+          "push_id": 350224,
+          "value": 565.57,
+          "signature_id": 1651449,
+          "id": 494227596,
+          "push_timestamp": 1529953361,
+          "job_id": 184783441,
+          "datetime": "2018-06-25T19:02:41.000Z"
+        },
+        {
+          "push_id": 350459,
+          "value": 581.68,
+          "signature_id": 1651449,
+          "id": 494637212,
+          "push_timestamp": 1530004839,
+          "job_id": 184888669,
+          "datetime": "2018-06-26T09:20:39.000Z"
+        },
+        {
+          "push_id": 350564,
+          "value": 573.18,
+          "signature_id": 1651449,
+          "id": 494931134,
+          "push_timestamp": 1530024738,
+          "job_id": 184962506,
+          "datetime": "2018-06-26T14:52:18.000Z"
+        },
+        {
+          "push_id": 350565,
+          "value": 571.51,
+          "signature_id": 1651449,
+          "id": 494940436,
+          "push_timestamp": 1530024819,
+          "job_id": 184965119,
+          "datetime": "2018-06-26T14:53:39.000Z"
+        },
+        {
+          "push_id": 350749,
+          "value": 568.71,
+          "signature_id": 1651449,
+          "id": 495284458,
+          "push_timestamp": 1530050017,
+          "job_id": 185041512,
+          "datetime": "2018-06-26T21:53:37.000Z"
+        },
+        {
+          "push_id": 350981,
+          "value": 563.05,
+          "signature_id": 1651449,
+          "id": 495722204,
+          "push_timestamp": 1530095079,
+          "job_id": 185135941,
+          "datetime": "2018-06-27T10:24:39.000Z"
+        },
+        {
+          "push_id": 350997,
+          "value": 572.85,
+          "signature_id": 1651449,
+          "id": 495745926,
+          "push_timestamp": 1530097540,
+          "job_id": 185143305,
+          "datetime": "2018-06-27T11:05:40.000Z"
+        },
+        {
+          "push_id": 351308,
+          "value": 577.39,
+          "signature_id": 1651449,
+          "id": 496242519,
+          "push_timestamp": 1530137129,
+          "job_id": 185267258,
+          "datetime": "2018-06-27T22:05:29.000Z"
+        },
+        {
+          "push_id": 351309,
+          "value": 566.55,
+          "signature_id": 1651449,
+          "id": 496255804,
+          "push_timestamp": 1530137288,
+          "job_id": 185270168,
+          "datetime": "2018-06-27T22:08:08.000Z"
+        },
+        {
+          "push_id": 351474,
+          "value": 564.04,
+          "signature_id": 1651449,
+          "id": 496496969,
+          "push_timestamp": 1530179042,
+          "job_id": 185340374,
+          "datetime": "2018-06-28T09:44:02.000Z"
+        },
+        {
+          "push_id": 351482,
+          "value": 563.61,
+          "signature_id": 1651449,
+          "id": 496517860,
+          "push_timestamp": 1530180318,
+          "job_id": 185345944,
+          "datetime": "2018-06-28T10:05:18.000Z"
+        }
+      ]
+    }
+  }
+}

--- a/test/mocks/linux64DromaeoDomData.json
+++ b/test/mocks/linux64DromaeoDomData.json
@@ -1,0 +1,426 @@
+{
+  "7174750fde7272ab7cb47cf0021604d46160dbc0": [
+    {
+      "push_id": 350159,
+      "value": 573.21,
+      "signature_id": 1651449,
+      "job_id": 184734903,
+      "push_timestamp": 1529944466,
+      "id": 494103361
+    },
+    {
+      "push_id": 350222,
+      "value": 574.66,
+      "signature_id": 1651449,
+      "job_id": 184785927,
+      "push_timestamp": 1529953295,
+      "id": 494234160
+    },
+    {
+      "push_id": 350224,
+      "value": 565.57,
+      "signature_id": 1651449,
+      "job_id": 184783441,
+      "push_timestamp": 1529953361,
+      "id": 494227596
+    },
+    {
+      "push_id": 350459,
+      "value": 581.68,
+      "signature_id": 1651449,
+      "job_id": 184888669,
+      "push_timestamp": 1530004839,
+      "id": 494637212
+    },
+    {
+      "push_id": 350564,
+      "value": 573.18,
+      "signature_id": 1651449,
+      "job_id": 184962506,
+      "push_timestamp": 1530024738,
+      "id": 494931134
+    },
+    {
+      "push_id": 350565,
+      "value": 571.51,
+      "signature_id": 1651449,
+      "job_id": 184965119,
+      "push_timestamp": 1530024819,
+      "id": 494940436
+    },
+    {
+      "push_id": 350749,
+      "value": 568.71,
+      "signature_id": 1651449,
+      "job_id": 185041512,
+      "push_timestamp": 1530050017,
+      "id": 495284458
+    },
+    {
+      "push_id": 350981,
+      "value": 563.05,
+      "signature_id": 1651449,
+      "job_id": 185135941,
+      "push_timestamp": 1530095079,
+      "id": 495722204
+    },
+    {
+      "push_id": 350997,
+      "value": 572.85,
+      "signature_id": 1651449,
+      "job_id": 185143305,
+      "push_timestamp": 1530097540,
+      "id": 495745926
+    },
+    {
+      "push_id": 351308,
+      "value": 577.39,
+      "signature_id": 1651449,
+      "job_id": 185267258,
+      "push_timestamp": 1530137129,
+      "id": 496242519
+    },
+    {
+      "push_id": 351309,
+      "value": 566.55,
+      "signature_id": 1651449,
+      "job_id": 185270168,
+      "push_timestamp": 1530137288,
+      "id": 496255804
+    },
+    {
+      "push_id": 351474,
+      "value": 564.04,
+      "signature_id": 1651449,
+      "job_id": 185340374,
+      "push_timestamp": 1530179042,
+      "id": 496496969
+    },
+    {
+      "push_id": 351482,
+      "value": 563.61,
+      "signature_id": 1651449,
+      "job_id": 185345944,
+      "push_timestamp": 1530180318,
+      "id": 496517860
+    }
+  ],
+  "019d05b26679ad400a8ec0a8f4259b876e0a7845": [
+    {
+      "push_id": 350159,
+      "value": 43613.49,
+      "signature_id": 1651448,
+      "job_id": 184734903,
+      "push_timestamp": 1529944466,
+      "id": 494103359
+    },
+    {
+      "push_id": 350222,
+      "value": 43800.94,
+      "signature_id": 1651448,
+      "job_id": 184785927,
+      "push_timestamp": 1529953295,
+      "id": 494234159
+    },
+    {
+      "push_id": 350224,
+      "value": 43361.01,
+      "signature_id": 1651448,
+      "job_id": 184783441,
+      "push_timestamp": 1529953361,
+      "id": 494227593
+    },
+    {
+      "push_id": 350459,
+      "value": 44384.92,
+      "signature_id": 1651448,
+      "job_id": 184888669,
+      "push_timestamp": 1530004839,
+      "id": 494637211
+    },
+    {
+      "push_id": 350564,
+      "value": 43559.86,
+      "signature_id": 1651448,
+      "job_id": 184962506,
+      "push_timestamp": 1530024738,
+      "id": 494931133
+    },
+    {
+      "push_id": 350565,
+      "value": 42958.32,
+      "signature_id": 1651448,
+      "job_id": 184965119,
+      "push_timestamp": 1530024819,
+      "id": 494940435
+    },
+    {
+      "push_id": 350749,
+      "value": 44050.19,
+      "signature_id": 1651448,
+      "job_id": 185041512,
+      "push_timestamp": 1530050017,
+      "id": 495284457
+    },
+    {
+      "push_id": 350981,
+      "value": 43613.63,
+      "signature_id": 1651448,
+      "job_id": 185135941,
+      "push_timestamp": 1530095079,
+      "id": 495722202
+    },
+    {
+      "push_id": 350997,
+      "value": 44179.09,
+      "signature_id": 1651448,
+      "job_id": 185143305,
+      "push_timestamp": 1530097540,
+      "id": 495745923
+    },
+    {
+      "push_id": 351308,
+      "value": 43183.1,
+      "signature_id": 1651448,
+      "job_id": 185267258,
+      "push_timestamp": 1530137129,
+      "id": 496242518
+    },
+    {
+      "push_id": 351309,
+      "value": 43164.28,
+      "signature_id": 1651448,
+      "job_id": 185270168,
+      "push_timestamp": 1530137288,
+      "id": 496255803
+    },
+    {
+      "push_id": 351474,
+      "value": 43267.26,
+      "signature_id": 1651448,
+      "job_id": 185340374,
+      "push_timestamp": 1530179042,
+      "id": 496496967
+    },
+    {
+      "push_id": 351482,
+      "value": 43280.85,
+      "signature_id": 1651448,
+      "job_id": 185345944,
+      "push_timestamp": 1530180318,
+      "id": 496517856
+    }
+  ],
+  "793d36ca61ba5e3727542b170237e7192c50cc6b": [
+    {
+      "push_id": 350159,
+      "value": 709.93,
+      "signature_id": 1651447,
+      "job_id": 184734903,
+      "push_timestamp": 1529944466,
+      "id": 494103356
+    },
+    {
+      "push_id": 350222,
+      "value": 732.16,
+      "signature_id": 1651447,
+      "job_id": 184785927,
+      "push_timestamp": 1529953295,
+      "id": 494234158
+    },
+    {
+      "push_id": 350224,
+      "value": 739.69,
+      "signature_id": 1651447,
+      "job_id": 184783441,
+      "push_timestamp": 1529953361,
+      "id": 494227591
+    },
+    {
+      "push_id": 350459,
+      "value": 746.11,
+      "signature_id": 1651447,
+      "job_id": 184888669,
+      "push_timestamp": 1530004839,
+      "id": 494637210
+    },
+    {
+      "push_id": 350564,
+      "value": 741.25,
+      "signature_id": 1651447,
+      "job_id": 184962506,
+      "push_timestamp": 1530024738,
+      "id": 494931132
+    },
+    {
+      "push_id": 350565,
+      "value": 704.93,
+      "signature_id": 1651447,
+      "job_id": 184965119,
+      "push_timestamp": 1530024819,
+      "id": 494940433
+    },
+    {
+      "push_id": 350749,
+      "value": 737.31,
+      "signature_id": 1651447,
+      "job_id": 185041512,
+      "push_timestamp": 1530050017,
+      "id": 495284456
+    },
+    {
+      "push_id": 350981,
+      "value": 732.79,
+      "signature_id": 1651447,
+      "job_id": 185135941,
+      "push_timestamp": 1530095079,
+      "id": 495722199
+    },
+    {
+      "push_id": 350997,
+      "value": 733.45,
+      "signature_id": 1651447,
+      "job_id": 185143305,
+      "push_timestamp": 1530097540,
+      "id": 495745921
+    },
+    {
+      "push_id": 351308,
+      "value": 723.12,
+      "signature_id": 1651447,
+      "job_id": 185267258,
+      "push_timestamp": 1530137129,
+      "id": 496242516
+    },
+    {
+      "push_id": 351309,
+      "value": 744.14,
+      "signature_id": 1651447,
+      "job_id": 185270168,
+      "push_timestamp": 1530137288,
+      "id": 496255802
+    },
+    {
+      "push_id": 351474,
+      "value": 704.69,
+      "signature_id": 1651447,
+      "job_id": 185340374,
+      "push_timestamp": 1530179042,
+      "id": 496496966
+    },
+    {
+      "push_id": 351482,
+      "value": 717.6,
+      "signature_id": 1651447,
+      "job_id": 185345944,
+      "push_timestamp": 1530180318,
+      "id": 496517850
+    }
+  ],
+  "78b8bec0338005afcc0c57d9622c18f55b0d6193": [
+    {
+      "push_id": 350159,
+      "value": 5511.63,
+      "signature_id": 1651446,
+      "job_id": 184734903,
+      "push_timestamp": 1529944466,
+      "id": 494103354
+    },
+    {
+      "push_id": 350222,
+      "value": 5621.31,
+      "signature_id": 1651446,
+      "job_id": 184785927,
+      "push_timestamp": 1529953295,
+      "id": 494234157
+    },
+    {
+      "push_id": 350224,
+      "value": 5905.06,
+      "signature_id": 1651446,
+      "job_id": 184783441,
+      "push_timestamp": 1529953361,
+      "id": 494227589
+    },
+    {
+      "push_id": 350459,
+      "value": 5673.6,
+      "signature_id": 1651446,
+      "job_id": 184888669,
+      "push_timestamp": 1530004839,
+      "id": 494637209
+    },
+    {
+      "push_id": 350564,
+      "value": 5771.27,
+      "signature_id": 1651446,
+      "job_id": 184962506,
+      "push_timestamp": 1530024738,
+      "id": 494931131
+    },
+    {
+      "push_id": 350565,
+      "value": 5479.64,
+      "signature_id": 1651446,
+      "job_id": 184965119,
+      "push_timestamp": 1530024819,
+      "id": 494940431
+    },
+    {
+      "push_id": 350749,
+      "value": 5399.81,
+      "signature_id": 1651446,
+      "job_id": 185041512,
+      "push_timestamp": 1530050017,
+      "id": 495284455
+    },
+    {
+      "push_id": 350981,
+      "value": 5648.08,
+      "signature_id": 1651446,
+      "job_id": 185135941,
+      "push_timestamp": 1530095079,
+      "id": 495722197
+    },
+    {
+      "push_id": 350997,
+      "value": 5783.3,
+      "signature_id": 1651446,
+      "job_id": 185143305,
+      "push_timestamp": 1530097540,
+      "id": 495745919
+    },
+    {
+      "push_id": 351308,
+      "value": 5659.75,
+      "signature_id": 1651446,
+      "job_id": 185267258,
+      "push_timestamp": 1530137129,
+      "id": 496242514
+    },
+    {
+      "push_id": 351309,
+      "value": 5604.71,
+      "signature_id": 1651446,
+      "job_id": 185270168,
+      "push_timestamp": 1530137288,
+      "id": 496255801
+    },
+    {
+      "push_id": 351474,
+      "value": 5802.03,
+      "signature_id": 1651446,
+      "job_id": 185340374,
+      "push_timestamp": 1530179042,
+      "id": 496496964
+    },
+    {
+      "push_id": 351482,
+      "value": 5188.06,
+      "signature_id": 1651446,
+      "job_id": 185345944,
+      "push_timestamp": 1530180318,
+      "id": 496517845
+    }
+  ]
+}

--- a/test/mocks/linux64DromaeoDomSubtests.json
+++ b/test/mocks/linux64DromaeoDomSubtests.json
@@ -1,0 +1,58 @@
+{
+  "793d36ca61ba5e3727542b170237e7192c50cc6b": {
+    "extra_options": [
+      "e10s",
+      "stylo"
+    ],
+    "suite": "dromaeo_dom",
+    "framework_id": 1,
+    "parent_signature": "947870e091eef0257755ce0e6fd6302e1704c15b",
+    "test": "modify.html",
+    "machine_platform": "linux64",
+    "id": 1651447,
+    "option_collection_hash": "f69e1b00908837bf0550250abb1645014317e8ec",
+    "lower_is_better": false
+  },
+  "78b8bec0338005afcc0c57d9622c18f55b0d6193": {
+    "extra_options": [
+      "e10s",
+      "stylo"
+    ],
+    "suite": "dromaeo_dom",
+    "framework_id": 1,
+    "parent_signature": "947870e091eef0257755ce0e6fd6302e1704c15b",
+    "test": "attr.html",
+    "machine_platform": "linux64",
+    "id": 1651446,
+    "option_collection_hash": "f69e1b00908837bf0550250abb1645014317e8ec",
+    "lower_is_better": false
+  },
+  "019d05b26679ad400a8ec0a8f4259b876e0a7845": {
+    "extra_options": [
+      "e10s",
+      "stylo"
+    ],
+    "suite": "dromaeo_dom",
+    "framework_id": 1,
+    "parent_signature": "947870e091eef0257755ce0e6fd6302e1704c15b",
+    "test": "query.html",
+    "machine_platform": "linux64",
+    "id": 1651448,
+    "option_collection_hash": "f69e1b00908837bf0550250abb1645014317e8ec",
+    "lower_is_better": false
+  },
+  "7174750fde7272ab7cb47cf0021604d46160dbc0": {
+    "extra_options": [
+      "e10s",
+      "stylo"
+    ],
+    "suite": "dromaeo_dom",
+    "framework_id": 1,
+    "parent_signature": "947870e091eef0257755ce0e6fd6302e1704c15b",
+    "test": "traverse.html",
+    "machine_platform": "linux64",
+    "id": 1651449,
+    "option_collection_hash": "f69e1b00908837bf0550250abb1645014317e8ec",
+    "lower_is_better": false
+  }
+}

--- a/test/mocks/readme.txt
+++ b/test/mocks/readme.txt
@@ -1,3 +1,11 @@
+NOTE: I'm only listing one benchmark: DromaeoDom
+
 Describe in this file where each JSON file was fetched from:
+* linux64DromaeoDomData.json (3 days worth of data instead of 90 days):
+https://treeherder.mozilla.org/api/project/mozilla-central/performance/data/?framework=1&interval=259200&signature_id=1651448&signature_id=1651449&signature_id=1651446&signature_id=1651447
+* linux64DromaeoDomSubtests.json:
+https://treeherder.mozilla.org/api/project/mozilla-central/performance/signatures/?format=json&parent_signature=947870e091eef0257755ce0e6fd6302e1704c15b
 * linux64SignaturesNoSubtests.json:
 https://treeherder.mozilla.org/api/project/mozilla-central/performance/signatures/?format=json&framework=1&platform=linux64&subtests=0
+* optionCollectionHash.json:
+https://treeherder.mozilla.org/api/optioncollectionhash/

--- a/yarn.lock
+++ b/yarn.lock
@@ -5665,7 +5665,7 @@ lodash.uniq@^4.5.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.17.5:
+lodash@^4.17.10, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
Fetching data for dromaeo_dom returns more than one pgo job since it
used to run in the past with different extraOptions (it now runs with e10s & stylo).